### PR TITLE
[CI] Add lint job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - $default-branch
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - uses: pre-commit/action@v2.0.0


### PR DESCRIPTION
This job will run [pre-commit] on the entire repository to ensure that
the linters are satisfied before a branch can be merged.

[pre-commit]: https://pre-commit.com
